### PR TITLE
Update 21_WRDS.Rmd

### DIFF
--- a/21_WRDS.Rmd
+++ b/21_WRDS.Rmd
@@ -403,7 +403,7 @@ compustat <- funda_db |>
   collect()
 ```
 
-Next, we calculate the book value of preferred stock and equity inspired by the [variable definition in Ken French's data library.](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/variable_definitions.html) Note that we set negative or zero equity to missing as it makes conceptually little sense (i.e., the firm would be bankrupt).\index{Book equity}\index{Preferred stock}
+Next, we calculate the book value of preferred stock and equity inspired by the [variable definition in Ken French's data library.](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/variable_definitions.html) Note that we set negative or zero equity to missing which is a common practice when working with book-to-market ratios [see @Fama1992 for details].\index{Book equity}\index{Preferred stock}
 
 ```{r}
 compustat <- compustat |>


### PR DESCRIPTION
This is actually incorrect.  A company can have negative book equity and not be bankrupt.  It will happen if the company has raised more debt than the value of its assets are worth, or if the company has enough years with negative retained earnings.  Dominos Pizza is an example of a company that has maintained negative book equity since it went public back in 2004 (currently its book equity is negative $4.2 billion - https://materials.proxyvote.com/Approved/25754A/20220302/AR_493369/INDEX.HTML?page=56).  In that time the stock price has increased 2,900%!  You still may want to exclude them as Fama and French do when constructing their portfolios if you are primarily using book equity for book to market ratios.  Fama and French (1992) has the following note...

"On average, only about 50 (out of 2317) firms per year have negative book equity, BE. The negative BE firms are mostly concentrated in the last 14 years of the sample, 1976–1989, and we do not include them in the tests. We can report, however, that average returns for negative BE firms are high, like the average returns of high BE/ME firms. Negative BE (which results from persistently negative earnings) and high BE/ME (which typically means that stock prices have fallen) are both signals of poor earning prospects. The similar average returns of negative and high BE/ME firms are thus consistent with the hypothesis that book-to-market equity captures cross-sectional variation in average returns that is related to relative distress."